### PR TITLE
Flat path before stroking outline

### DIFF
--- a/src/obs-text-pthread-thread.c
+++ b/src/obs-text-pthread-thread.c
@@ -82,6 +82,13 @@ static void tp_stroke_path(cairo_t *cr, PangoLayout *layout, const struct tp_con
 			}
 			if (!path_preserved)
 				pango_cairo_layout_path(cr, layout);
+			if (!path_preserved) { // workaround
+				cairo_path_t *path;
+				path = cairo_copy_path_flat(cr);
+				cairo_new_path(cr);
+				cairo_append_path(cr, path);
+				cairo_path_destroy(path);
+			}
 			cairo_stroke_preserve(cr);
 			path_preserved = true;
 		}


### PR DESCRIPTION
This change is a workaround for a thick outline inside a circle (issue #14). The problem happens when stroking curves but lines are ok. Each curve is converted to multiple lines.
The drawback is possibly runtime increase. I don't want to use this if another approach works.