### PR TITLE
CI(macOS/x86_64): Force macOS version to 10.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,15 +76,17 @@ jobs:
           ls /usr/share/obs/obs-plugins/${PLUGIN_NAME}/
 
   macos_build:
-    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
         include:
           - obs: 27
             arch: x86_64
+            host: macos-10.15
           - obs: 28
             arch: arm64
+            host: macos-11
+    runs-on: ${{ matrix.host }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Edit brew script to force macOS ~~10.13~~ 10.15.

10.13 requires libraries from brew to be built from the source, which took too much time.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
