### PR TITLE
CI(macOS): Use macOS 11 to build both x86_64 and arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,17 +76,15 @@ jobs:
           ls /usr/share/obs/obs-plugins/${PLUGIN_NAME}/
 
   macos_build:
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
         include:
           - obs: 27
             arch: x86_64
-            host: macos-10.15
           - obs: 28
             arch: arm64
-            host: macos-11
-    runs-on: ${{ matrix.host }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- This reverts commit 3b6421c30da45f509246e071b632e04ff2c512a9.
- Then modify macos-12 to macos-11.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Confirmed CI build with tag has passed.
https://github.com/norihiro/obs-text-pthread/runs/7876733892

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
