### PR TITLE
CI(macOS): Build bundle-type plugin package with universal binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,7 +274,6 @@ jobs:
     env:
       visualStudio: 'Visual Studio 17 2022'
       Configuration: 'RelWithDebInfo'
-      LIBVNCPath: ${{ github.workspace }}'\libvncserver'
     defaults:
       run:
         shell: pwsh
@@ -290,13 +289,6 @@ jobs:
           obs: ${{ matrix.obs }}
           qt: ${{ env.qt }}
 
-      - name: Build libvncserver
-        shell: cmd
-        run: ci/windows/install-libvncserver.cmd
-        env:
-          CMakeOptA: x64
-          build_config: RelWithDebInfo
-
       - name: Build plugin
         run: |
           $CmakeArgs = @(
@@ -305,9 +297,6 @@ jobs:
             '-DCMAKE_SYSTEM_VERSION=10.0.18363.657'
             "-DCMAKE_INSTALL_PREFIX=$(Resolve-Path -Path "./obs-build-dependencies/plugin-deps-${{ matrix.arch }}")"
             "-DCMAKE_PREFIX_PATH=$(Resolve-Path -Path "./obs-build-dependencies/plugin-deps-${{ matrix.arch }}")"
-            "-DLIBVNCCLIENT_INCLUDE_DIRS=%LIBVNCPath%"
-            "-DLIBVNCCLIENT_STATIC_LIBRARY_DIRS=%LIBVNCPath%"
-            "-DLIBVNCCLIENT_STATIC_LIBRARIES=%LIBVNCPath%\RelWithDebInfo\vncclient.lib;%LIBVNCPath%\deps\zlib\RelWithDebInfo\zlibstatic.lib;%LIBVNCPath%\deps\lzo\build\RelWithDebInfo\lzo2.lib;%LIBVNCPath%\deps\libpng\RelWithDebInfo\libpng16_static.lib;%LIBVNCPath%\deps\libjpeg\RelWithDebInfo\turbojpeg-static.lib;wsock32.lib;ws2_32.lib"
           )
           cmake -S . -B build @CmakeArgs
           cmake --build build --config RelWithDebInfo -j 4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,16 @@ jobs:
           PKG_SUFFIX=-${GIT_TAG}-obs${{ matrix.obs }}-macos-${{ matrix.arch }}
           export PKG_CONFIG_PATH=/usr/local/opt/arm64/lib/pkgconfig:$deps/lib/pkgconfig:/usr/local/lib/pkgconfig/:$PKG_CONFIG_PATH # for arm64
           set -e
+          case "${{ matrix.obs }}" in
+            27)
+              cmake_opt=()
+              ;;
+            28)
+              cmake_opt=(
+                -D MACOSX_PLUGIN_BUNDLE_TYPE=BNDL
+              )
+              ;;
+          esac
           cmake -S . -B build -G Ninja \
             -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -164,7 +174,8 @@ jobs:
             -DCMAKE_OSX_ARCHITECTURES=$arch \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
             -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
-            -D PKG_SUFFIX=$PKG_SUFFIX
+            -D PKG_SUFFIX=$PKG_SUFFIX \
+            "${cmake_opt[@]}"
           cmake --build build --config RelWithDebInfo
           echo "PKG_SUFFIX='$PKG_SUFFIX'" >> ci/ci_includes.generated.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   artifactName: ${{ contains(github.ref_name, '/') && 'artifact' || github.ref_name }}
+  qt: false
 
 jobs:
   linux_build:
@@ -40,6 +41,7 @@ jobs:
         with:
           obs: ${{ matrix.obs }}
           verbose: true
+          qt: ${{ env.qt }}
 
       - name: Build plugin
         run: |
@@ -140,6 +142,7 @@ jobs:
           arch: ${{ matrix.arch }}
           obs: ${{ matrix.obs }}
           verbose: true
+          qt: ${{ env.qt }}
 
       - name: Install pango
         run: |
@@ -285,6 +288,7 @@ jobs:
         uses: norihiro/obs-studio-devel-action@v1-beta
         with:
           obs: ${{ matrix.obs }}
+          qt: ${{ env.qt }}
 
       - name: Build libvncserver
         shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
           p12-password: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
 
       - name: Set Signing Identity
-        if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           set -e
           TEAM_ID=$(echo "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" | sed 's/.*(\([A-Za-z0-9]*\))$/\1/')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,28 +184,53 @@ jobs:
           set -ex
           . ci/ci_includes.generated.sh
           cmake --install build --config RelWithDebInfo --prefix=release
-          (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
-          cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+          case ${{ matrix.obs }} in
+            27)
+              (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
+              cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+              ;;
+            28)
+              (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ MacOS/${PLUGIN_NAME})
+              cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
+              ;;
+          esac
 
       - name: Codesign
         if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           . ci/ci_includes.generated.sh
-          for dylib in release/${PLUGIN_NAME}/lib/*.dylib; do
-            test -f "$dylib" || continue
-            codesign --remove-signature "$dylib"
+          set -e
+          case ${{ matrix.obs }} in
+            27)
+              files=(
+                $(find release/${PLUGIN_NAME}/ -name '*.dylib')
+                release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so
+              )
+              ;;
+            28)
+              files=(
+                $(find release/${PLUGIN_NAME}.plugin/ -name '*.dylib')
+                release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
+              )
+              ;;
+          esac
+          for dylib in "${files[@]}"; do
+            codesign --force --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
           done
-          for dylib in release/${PLUGIN_NAME}/*/*.{so,dylib}; do
-            test -f "$dylib" || continue
-            codesign --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
+          for dylib in "${files[@]}"; do
+            codesign -vvv --deep --strict "$dylib"
           done
 
       - name: Package
         run: |
           . ci/ci_includes.generated.sh
+          set -ex
           zipfile=$PWD/package/${PLUGIN_NAME}${PKG_SUFFIX}.zip
           mkdir package
-          (cd release/ && zip -r $zipfile $PLUGIN_NAME)
+          case ${{ matrix.obs }} in
+            27) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}) ;;
+            28) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}.plugin) ;;
+          esac
           ci/macos/install-packagesbuild.sh
           packagesbuild \
             --build-folder $PWD/package/ \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ if(OS_MACOS)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fvisibility=default")
 
 	set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES PREFIX "")
+	set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
+	set(MACOSX_PLUGIN_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
+	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
+
 	configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,8 @@ if(OS_MACOS)
 	set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
 	set(MACOSX_PLUGIN_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
 	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
-
-	configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)
 endif()
 
 setup_plugin_target(${CMAKE_PROJECT_NAME})
+
+configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)

--- a/ci/macos/change-rpath.sh
+++ b/ci/macos/change-rpath.sh
@@ -21,7 +21,9 @@ set -e
 function copy_local_dylib
 {
 	local dylib
-	otool -L $1 | awk '/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}' |
+	t=$(mktemp)
+	otool -L $1 > $t
+	awk '/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}' $t |
 	while read -r dylib; do
 		echo "Changing dependency $1 -> $dylib"
 		local b=$(basename $dylib)
@@ -34,6 +36,7 @@ function copy_local_dylib
 		fi
 		install_name_tool -change "$dylib" "@loader_path/../$libdir/$b" $1
 	done
+	rm -f "$t"
 }
 
 function change_obs27_libs

--- a/ci/macos/install-packagesbuild.sh
+++ b/ci/macos/install-packagesbuild.sh
@@ -6,7 +6,7 @@ if which packagesbuild; then
 	exit 0
 fi
 
-packages_url='http://s.sudre.free.fr/Software/files/Packages.dmg'
+packages_url='http://www.nagater.net/obs-studio/Packages.dmg'
 packages_hash='6afdd25386295974dad8f078b8f1e41cabebd08e72d970bf92f707c7e48b16c9'
 
 for ((retry=5; retry>0; retry--)); do

--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -110,6 +110,32 @@ if(OS_MACOS)
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH OFF)
 
 	function(setup_plugin_target target)
+		if(NOT DEFINED MACOSX_PLUGIN_GUI_IDENTIFIER)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_GUI_IDENTIFIER' set, but is required to build plugin bundles on macOS - example: 'com.yourname.pluginname'"
+				)
+		endif()
+
+		if(NOT DEFINED MACOSX_PLUGIN_BUNDLE_VERSION)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_BUNDLE_VERSION' set, but is required to build plugin bundles on macOS - example: '25'"
+				)
+		endif()
+
+		if(NOT DEFINED MACOSX_PLUGIN_SHORT_VERSION_STRING)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_SHORT_VERSION_STRING' set, but is required to build plugin bundles on macOS - example: '1.0.2'"
+				)
+		endif()
+
+		set(MACOSX_PLUGIN_BUNDLE_NAME "${target}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_BUNDLE_VERSION "${MACOSX_BUNDLE_BUNDLE_VERSION}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_SHORT_VERSION_STRING "${MACOSX_BUNDLE_SHORT_VERSION_STRING}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_EXECUTABLE_NAME "${target}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_BUNDLE_TYPE "BNDL" PARENT_SCOPE)
 
 		install(
 			TARGETS ${target}

--- a/cmake/bundle/macos/Plugin-Info.plist.in
+++ b/cmake/bundle/macos/Plugin-Info.plist.in
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_PLUGIN_GUI_IDENTIFIER}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_PLUGIN_SHORT_VERSION_STRING}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_PLUGIN_EXECUTABLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_TYPE}</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.13</string>
+</dict>
+</plist>

--- a/cmake/bundle/macos/entitlements.plist
+++ b/cmake/bundle/macos/entitlements.plist
@@ -1,0 +1,17 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.device.camera</key>
+        <true/>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+        <!-- Allows @executable_path to load libaries from within the .app bundle. -->
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true/>
+    </dict>
+</plist>

--- a/installer/installer-macOS.pkgproj.in
+++ b/installer/installer-macOS.pkgproj.in
@@ -63,7 +63,7 @@
 															<key>GID</key>
 															<integer>80</integer>
 															<key>PATH</key>
-															<string>../@RELATIVE_INSTALL_PATH@/@CMAKE_PROJECT_NAME@</string>
+															<string>../@RELATIVE_INSTALL_PATH@/@CMAKE_PROJECT_NAME@@FIRST_DIR_SUFFIX@</string>
 															<key>PATH_TYPE</key>
 															<integer>1</integer>
 															<key>PERMISSIONS</key>


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- Set bundle type plugin package
- ~~Build universal binary instead of arm64 for OBS 28~~ Universal binary is not feasible for the libraries copied from brew.
- Remove unnecessary code installing libvncserver
- And some more modifications from my other plugins


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
