### PR TITLE
CI(macOS/ARM64): Fix 2nd level dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,10 +191,12 @@ jobs:
             27)
               (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
               cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+              ci/macos/test-dylib.sh -27 release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so
               ;;
             28)
               (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ MacOS/${PLUGIN_NAME})
               cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
+              ci/macos/test-dylib.sh -28 release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
               ;;
           esac
 

--- a/ci/macos/change-rpath.sh
+++ b/ci/macos/change-rpath.sh
@@ -23,13 +23,38 @@ function copy_local_dylib
 	local dylib
 	t=$(mktemp)
 	otool -L $1 > $t
-	awk '/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}' $t |
-	while read -r dylib; do
+	awk '
+	/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}
+	$1 ~ /^@@HOMEBREW_CELLAR@@\/.*\.dylib/{
+		pango_path = $1
+		sub("@@HOMEBREW_CELLAR@@/[^/]*/[^/]*/", "/usr/local/opt/arm64/", pango_path);
+		print $1, pango_path
+	}
+	' $t |
+	while read -r dylib pango_path; do
 		echo "Changing dependency $1 -> $dylib"
 		local b=$(basename $dylib)
+		case "$dylib" in
+			@@HOMEBREW_CELLAR@@*.dylib)
+				dylib_path="$pango_path"
+				if ! test -f "$dylib_path"; then
+					echo "Warning: File $dylib_path not found. Searching..."
+					dylib_path=$(find /usr/local/opt/arm64/ -name "$b" | head -n 1)
+					if test -f "$dylib_path"; then
+						echo "Found $dylib_path"
+					else
+						echo "Error: $b not found."
+						exit 1
+					fi
+				fi
+				;;
+			*)
+				dylib_path="$dylib"
+				;;
+		esac
 		if test ! -e $libdir/$b; then
 			mkdir -p $libdir
-			cp $dylib $libdir
+			cp $dylib_path $libdir
 			chmod +rwx $libdir/$b
 			install_name_tool -id "@loader_path/$b" $libdir/$b
 			copy_local_dylib $libdir/$b

--- a/ci/macos/test-dylib.sh
+++ b/ci/macos/test-dylib.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+
+set -e
+
+obs=28
+
+function test_dylib
+{
+	echo "$1" >> $2
+	if ! test -e "$1"; then
+		echo "Error: File $1 not found." >&2
+		return 1
+	fi
+	loader_path="$(dirname "$1")"
+	otool -L "$1" |
+	awk -v loader_path="$loader_path" '
+	NR>=2 {
+		dylib = $1
+		sub("@loader_path", loader_path, dylib)
+		print dylib
+	}' | {
+		ret=0
+		while read dylib; do
+			case "$obs-$dylib" in
+				2?-/System/*) continue;;
+				2?-/usr/lib/*) continue;; # Some libraries are not found on the host for CI.
+				27-@rpath/libobs.0.dylib) continue;;
+				27-@rpath/libobs-frontend-api.dylib) continue;;
+				27-@executable_path/../Frameworks/Qt*.framework/Versions/5/Qt*) continue;;
+				28-@rpath/libobs.framework/Versions/A/libobs) continue;;
+				28-@rpath/libobs-frontend-api.1.dylib) continue;;
+				28-@rpath/Qt*.framework/Versions/A/Qt*) continue;;
+			esac
+			if ! grep -qF "$dylib" "$2"; then
+				if ! test_dylib "$dylib" "$2"; then
+					echo "Error: File $1 has a dependency error." >&2
+					ret=1
+				fi
+			fi
+		done
+		return $ret
+	}
+}
+
+for i in "$@"; do
+	case "$i" in
+		-27) obs=27;;
+		-28) obs=28;;
+		*) test_dylib "$i" $(mktemp);;
+	esac
+done


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->
This is a quick workaround to fix unresolved 2nd and deeper level libraries.

Also add a test to check wrong dependencies.

Libraries from brew has library paths starting `@@HOMEBREW_CELLAR@@` because I didn't use the right install flow. It causes the libraries not correctly bundled to the package.

Better solution might be using the proper install flow by just modifying the architecture detection in the brew.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
- [ ] Check `otool -L` for each bundled dylib file.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
