### PR TITLE
cmake: Set LANGUAGE C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(obs-text-pthread VERSION 2.0.3)
+project(obs-text-pthread VERSION 2.0.3
+	LANGUAGES C
+)
 
 set(PLUGIN_AUTHOR "Norihiro Kamae")
 set(MACOS_BUNDLEID "net.nagater.obs-text-pthread")


### PR DESCRIPTION
### Description
C++ compiler is not needed; do not require it.

(Context is a minimum-dependency docker based build).

### How Has This Been Tested?
Tested in a docker based build with Ubuntu 24.04 and OBS 30.1.0 and gcc (but not g++).

Before this change, cmake complains if no C++ compiler is installed, even though C++ isn't used.  After this change, the plugin builds fine with just gcc installed.

### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
