### PR TITLE
Ensure bmalloc always takes positive size

### DIFF
--- a/src/obs-text-pthread-thread.c
+++ b/src/obs-text-pthread-thread.c
@@ -136,6 +136,8 @@ static void tp_stroke_path(cairo_t *cr, PangoLayout *layout, const struct tp_con
 		cairo_surface_t *surface = cairo_get_target(cr);
 		const int w = cairo_image_surface_get_width(surface);
 		const int h = cairo_image_surface_get_height(surface);
+		if (w <= 0 || h <= 0)
+			return;
 		uint8_t *data = cairo_image_surface_get_data(surface);
 		const int bs1 = bs + 1;
 		uint32_t *tmp = bzalloc(sizeof(uint32_t) * w * bs1);
@@ -237,6 +239,12 @@ static struct tp_texture *tp_draw_texture(struct tp_config *config, char *text)
 	uint32_t surface_height = config->height + outline_width_blur * 2 + shadow_abs_y;
 
 	int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, surface_width);
+
+	if (!surface_width || !surface_height || stride <= 0) {
+		blog(LOG_ERROR, "nothing to draw: %ux%u stride=%d", surface_width, surface_height, stride);
+		return n;
+	}
+
 	n->surface = bzalloc(stride * surface_height);
 
 	cairo_surface_t *surface = cairo_image_surface_create_for_data(n->surface, CAIRO_FORMAT_ARGB32, surface_width,
@@ -600,7 +608,7 @@ static void *tp_thread_main(void *data)
 			if (b_printable) {
 				tex = tp_draw_texture(&config_prev, text);
 #ifdef PNG_FOUND
-				if (config_prev.save_file) {
+				if (config_prev.save_file && tex->width > 0 && tex->height > 0) {
 					png_width = tex->width;
 					png_height = tex->height;
 					png_surface = bzalloc(4 * png_width * png_height);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

OBS Studio >= 31.0.0 requires `bmalloc` always takes positive size, or it will crash.

This commit ensures the size is always positive.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

I have not tested yet.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
