### PR TITLE
.github: Update clang-format-18

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Clang
       run: |
-        sudo apt-get install -y clang-format-12
+        sudo apt-get install -y clang-format-18
         clang-format -i -fallback-style=none $(git ls-files | grep '\.\(c\|h\)$')
 
     - name: Check


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Since clang-format-12 is no longer available, upgrade clang-format to version 18.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

CI will test.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
