### PR TITLE
.github: Set ErrorActionPreference = "Stop"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -320,12 +320,15 @@ jobs:
 
       - name: Setup dependencies
         run: |
+          $ErrorActionPreference = "Stop"
           mkdir -force ${{ github.workspace }}\.vcpkg-binary-cache > $null
           $env:VCPKG_BINARY_SOURCES="files,${{ github.workspace }}\.vcpkg-binary-cache,readwrite"
           git clone https://github.com/microsoft/vcpkg.git vcpkg
           .\vcpkg\bootstrap-vcpkg.bat
           .\vcpkg\vcpkg.exe install pango cairo --triplet x64-windows-static
+          if ($LASTEXITCODE) { throw }
           .\vcpkg\vcpkg.exe install pkgconf:x64-windows
+          if ($LASTEXITCODE) { throw }
 
       - uses: actions/cache/save@v4
         with:
@@ -339,6 +342,7 @@ jobs:
 
       - name: Build plugin
         run: |
+          $ErrorActionPreference = "Stop"
           $CmakeArgs = @(
             '-G', "${{ env.visualStudio }}"
             '-DCMAKE_SYSTEM_VERSION=10.0.18363.657'


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The first attempt of this flow failed to install cairo but the script didn't stop.
- https://github.com/norihiro/obs-text-pthread/actions/runs/19183265243

This PR sets `ErrorActionPreference` to stop immediately after the command has failed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
